### PR TITLE
Fix 0.9.10 XCMP

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -78,8 +78,8 @@ parachain-staking = { path = '../pallets/parachain-staking', default-features = 
 pallet-author-mapping = { path = "../pallets/author-mapping", default-features = false }
 
 [features]
-default = ['std']
-enable-xcm = ['default']
+default = ['std', 'enable-xcm']
+enable-xcm = []
 runtime-benchmarks = [
     'hex-literal',
     'frame-benchmarking',

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -78,8 +78,7 @@ parachain-staking = { path = '../pallets/parachain-staking', default-features = 
 pallet-author-mapping = { path = "../pallets/author-mapping", default-features = false }
 
 [features]
-default = ['std', 'enable-xcm']
-enable-xcm = []
+default = ['std']
 runtime-benchmarks = [
     'hex-literal',
     'frame-benchmarking',


### PR DESCRIPTION
Fix compilation of XCMP-related code.

Removing of `enable-xcm` feature is made in a separate commit