### PR TITLE
Refactor sp-mvm/tests/assets.rs

### DIFF
--- a/pallets/sp-mvm/tests/balances.rs
+++ b/pallets/sp-mvm/tests/balances.rs
@@ -5,7 +5,7 @@ use move_core_types::language_storage::StructTag;
 use move_core_types::account_address::AccountAddress;
 
 mod common;
-use common::assets::*;
+use common::assets::{modules, transactions};
 use common::mock::*;
 use common::addr::*;
 use common::utils::*;
@@ -31,7 +31,7 @@ where
     };
     let tag = StructTag {
         address,
-        module: Identifier::new(UserMod::Store.name()).unwrap(),
+        module: Identifier::new(modules::user::STORE.name()).unwrap(),
         name: Identifier::new("U128").unwrap(),
         type_params: vec![],
     };
@@ -47,7 +47,7 @@ where
     };
     let tag = StructTag {
         address,
-        module: Identifier::new(UserMod::Store.name()).unwrap(),
+        module: Identifier::new(modules::user::STORE.name()).unwrap(),
         name: Identifier::new("U64").unwrap(),
         type_params: vec![],
     };
@@ -60,10 +60,10 @@ fn execute_get_balance() {
         let account = origin_ps_acc();
 
         // publish user module:
-        publish_module(account, UserMod::Store, None).unwrap();
+        publish_module(account, &modules::user::STORE, None).unwrap();
 
         // execute tx:
-        let result = execute_tx(account, UserTx::StoreGetBalance, None);
+        let result = execute_tx(account, &transactions::STORE_NATIVE_BALANCE, None);
         assert_ok!(result);
 
         // check storage:
@@ -84,10 +84,10 @@ fn execute_transfer() {
         eprintln!("Bob balance: {}", bob_init_balance);
 
         // publish user module
-        publish_module(bob, UserMod::Store, None).unwrap();
+        publish_module(bob, &modules::user::STORE, None).unwrap();
 
         // execute tx:
-        let result = execute_tx(bob, UserTx::Transfer, None);
+        let result = execute_tx(bob, &transactions::TRANSFER, None);
         assert_ok!(result);
 
         // check storage balance:

--- a/pallets/sp-mvm/tests/common/assets.rs
+++ b/pallets/sp-mvm/tests/common/assets.rs
@@ -1,215 +1,120 @@
 #![allow(dead_code)]
 
-const ROOT_PACKAGES: &[&str] = &["Assets"];
-const ROOT_PACKAGES_BYTECODE: &[&[u8]] = &[include_bytes!(
-    "../assets/root/artifacts/bundles/assets.pac"
-)];
-const ROOT_PACKAGES_MODULES: &[&[&str]] = &[&["Store", "EventProxy"]];
+use once_cell::sync::OnceCell;
+use std::path::Path;
 
-const USR_PACKAGES: &[&str] = &["Assets"];
-const USR_PACKAGES_BYTECODE: &[&[u8]] = &[include_bytes!(
-    "../assets/user/artifacts/bundles/assets.pac"
-)];
-const USR_PACKAGES_MODULES: &[&[&str]] = &[&["Store", "EventProxy"]];
-
-const USER_MODULES: &[&str] = &["Store", "EventProxy"];
-const USER_BYTECODE: &[&[u8]] = &[
-    include_bytes!("../assets/user/artifacts/modules/2_Store.mv"),
-    include_bytes!("../assets/user/artifacts/modules/47_EventProxy.mv"),
-];
-
-const ROOT_MODULES: &[&str] = &["Store", "EventProxy"];
-const ROOT_BYTECODE: &[&[u8]] = &[
-    include_bytes!("../assets/root/artifacts/modules/0_Store.mv"),
-    include_bytes!("../assets/root/artifacts/modules/1_EventProxy.mv"),
-];
-
-const TX_NAMES: &[&str] = &[
-    "store_u64",
-    "emit_event",
-    "store_system_block",
-    "store_system_timestamp",
-    "inf_loop",
-    "store_native_balance",
-    "transfer",
-    // "store_native_deposit",
-    // "store_native_deposit_reg",
-    // "store_native_withdraw",
-    // "store_native_withdraw_reg",
-    // "get_price_test",
-    // "missed_native_balance",
-];
-const TX_BYTECODE: &[&[u8]] = &[
-    include_bytes!("../assets/user/artifacts/transactions/store_u64.mvt"),
-    include_bytes!("../assets/user/artifacts/transactions/emit_event.mvt"),
-    include_bytes!("../assets/user/artifacts/transactions/store_system_block.mvt"),
-    include_bytes!("../assets/user/artifacts/transactions/store_system_timestamp.mvt"),
-    include_bytes!("../assets/user/artifacts/transactions/inf_loop.mvt"),
-    include_bytes!("../assets/user/artifacts/transactions/store_native_balance.mvt"),
-    include_bytes!("../assets/user/artifacts/transactions/transfer.mvt"),
-    include_bytes!("../assets/user/artifacts/transactions/multisig_test.mvt"),
-    // include_bytes!("../assets/user/artifacts/transactions/store_native_deposit.mvt"),
-    // include_bytes!("../assets/user/artifacts/transactions/store_native_deposit_reg.mvt"),
-    // include_bytes!("../assets/user/artifacts/transactions/store_native_withdraw.mvt"),
-    // include_bytes!("../assets/user/artifacts/transactions/store_native_withdraw_reg.mvt"),
-    // include_bytes!("../assets/user/artifacts/transactions/get_price_test.mvt"),
-    // include_bytes!("../assets/user/artifacts/transactions/missed_native_balance.mvt"),
-];
-
-pub trait BinAsset: Sized + Copy + Into<usize> {
-    const NAMES: &'static [&'static str];
-    const BYTES: &'static [&'static [u8]];
-
-    fn name(&self) -> &'static str {
-        Self::NAMES[(*self).into()]
-    }
-    fn bc(&self) -> &'static [u8] {
-        Self::BYTES[(*self).into()]
-    }
-
-    fn all() -> &'static [Self];
+#[derive(Clone)]
+pub struct Asset {
+    name: &'static str,
+    path: &'static str,
+    bytes: OnceCell<Vec<u8>>,
 }
 
-pub trait BinAssetPackage: BinAsset {
-    const MODULES: &'static [&'static [&'static str]];
+impl Asset {
+    pub const fn new(name: &'static str, path: &'static str) -> Self {
+        Self {
+            name,
+            path,
+            bytes: OnceCell::new(),
+        }
+    }
 
-    fn modules(&self) -> &[&'static str] {
-        Self::MODULES[(*self).into()]
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+
+    pub fn bytes(&self) -> &[u8] {
+        self.bytes
+            .get_or_init(|| {
+                let dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+                let path = Path::new(dir.as_str()).join(self.path);
+                std::fs::read(&path)
+                    .unwrap_or_else(|_| panic!("Failed to load test asset: {:?}", path.display()))
+            })
+            .as_slice()
     }
 }
 
-#[repr(usize)]
-#[derive(Copy, Clone, Debug)]
-pub enum UserMod {
-    Store = 0,
-    EventProxy = 1,
+pub struct Package {
+    modules: &'static [&'static str],
+    package: Asset,
 }
 
-#[repr(usize)]
-#[derive(Copy, Clone, Debug)]
-pub enum RootMod {
-    Store = 0,
-    EventProxy = 1,
-}
-
-#[repr(usize)]
-#[derive(Copy, Clone, Debug)]
-pub enum RootPackages {
-    Assets = 0,
-}
-
-#[repr(usize)]
-#[derive(Copy, Clone, Debug)]
-pub enum UsrPackages {
-    Assets = 0,
-}
-
-#[repr(usize)]
-#[derive(Copy, Clone, Debug)]
-pub enum UserTx {
-    StoreU64 = 0,
-    EmitEvent = 1,
-    StoreSysBlock = 2,
-    StoreSysTime = 3,
-    InfLoop = 4,
-    StoreGetBalance = 5,
-    Transfer = 6,
-    MultisigTest = 7,
-    //StoreNativeDeposit = 6,
-    //StoreNativeDepositReg = 7,
-    //StoreNativeWithdraw = 8,
-    //StoreNativeWithdrawReg = 9,
-    //GetPriceTest = 10,
-    //MissedNativeBalance = 11,
-}
-
-impl Into<usize> for UserMod {
-    fn into(self) -> usize {
-        self as usize
+impl Package {
+    pub const fn new(modules: &'static [&'static str], package: Asset) -> Self {
+        Self { modules, package }
+    }
+    pub fn modules(&self) -> &'static [&'static str] {
+        self.modules
+    }
+    pub fn bytes(&self) -> &[u8] {
+        self.package.bytes()
     }
 }
 
-impl Into<usize> for RootMod {
-    fn into(self) -> usize {
-        self as usize
+pub static ROOT_PACKAGE: Package = Package::new(
+    &["Store", "EventProxy"],
+    Asset::new("", "tests/assets/root/artifacts/bundles/assets.pac"),
+);
+pub static USER_PACKAGE: Package = Package::new(
+    &["Store", "EventProxy"],
+    Asset::new("", "tests/assets/user/artifacts/bundles/assets.pac"),
+);
+
+pub mod modules {
+    pub mod root {
+        use super::super::Asset;
+        pub static STORE: Asset =
+            Asset::new("Store", "tests/assets/root/artifacts/modules/0_Store.mv");
+        pub static EVENT_PROXY: Asset = Asset::new(
+            "EventProxy",
+            "tests/assets/root/artifacts/modules/1_EventProxy.mv",
+        );
+    }
+
+    pub mod user {
+        use super::super::Asset;
+        pub static STORE: Asset =
+            Asset::new("Store", "tests/assets/user/artifacts/modules/2_Store.mv");
+        pub static EVENT_PROXY: Asset = Asset::new(
+            "EventProxy",
+            "tests/assets/user/artifacts/modules/47_EventProxy.mv",
+        );
     }
 }
 
-impl Into<usize> for RootPackages {
-    fn into(self) -> usize {
-        self as usize
-    }
-}
-
-impl Into<usize> for UsrPackages {
-    fn into(self) -> usize {
-        self as usize
-    }
-}
-
-impl Into<usize> for UserTx {
-    fn into(self) -> usize {
-        self as usize
-    }
-}
-
-impl BinAsset for UserMod {
-    const NAMES: &'static [&'static str] = USER_MODULES;
-    const BYTES: &'static [&'static [u8]] = USER_BYTECODE;
-
-    fn all() -> &'static [Self] {
-        &[Self::Store, Self::EventProxy]
-    }
-}
-
-impl BinAsset for RootMod {
-    const NAMES: &'static [&'static str] = ROOT_MODULES;
-    const BYTES: &'static [&'static [u8]] = ROOT_BYTECODE;
-
-    fn all() -> &'static [Self] {
-        &[Self::Store, Self::EventProxy]
-    }
-}
-
-impl BinAsset for UserTx {
-    const NAMES: &'static [&'static str] = TX_NAMES;
-    const BYTES: &'static [&'static [u8]] = TX_BYTECODE;
-
-    fn all() -> &'static [Self] {
-        &[
-            Self::StoreU64,
-            Self::EmitEvent,
-            Self::StoreSysBlock,
-            Self::StoreSysTime,
-            Self::InfLoop,
-            Self::StoreGetBalance,
-            Self::Transfer,
-        ]
-    }
-}
-
-impl BinAsset for RootPackages {
-    const NAMES: &'static [&'static str] = ROOT_PACKAGES;
-    const BYTES: &'static [&'static [u8]] = ROOT_PACKAGES_BYTECODE;
-
-    fn all() -> &'static [Self] {
-        &[Self::Assets]
-    }
-}
-
-impl BinAssetPackage for RootPackages {
-    const MODULES: &'static [&'static [&'static str]] = ROOT_PACKAGES_MODULES;
-}
-
-impl BinAsset for UsrPackages {
-    const NAMES: &'static [&'static str] = USR_PACKAGES;
-    const BYTES: &'static [&'static [u8]] = USR_PACKAGES_BYTECODE;
-
-    fn all() -> &'static [Self] {
-        &[Self::Assets]
-    }
-}
-
-impl BinAssetPackage for UsrPackages {
-    const MODULES: &'static [&'static [&'static str]] = USR_PACKAGES_MODULES;
+pub mod transactions {
+    use super::Asset;
+    pub static STORE_U64: Asset = Asset::new(
+        "store_u64",
+        "tests/assets/user/artifacts/transactions/store_u64.mvt",
+    );
+    pub static EMIT_EVENT: Asset = Asset::new(
+        "emit_event",
+        "tests/assets/user/artifacts/transactions/emit_event.mvt",
+    );
+    pub static STORE_SYSTEM_BLOCK: Asset = Asset::new(
+        "store_system_block",
+        "tests/assets/user/artifacts/transactions/store_system_block.mvt",
+    );
+    pub static STORE_SYSTEM_TIMESTAMP: Asset = Asset::new(
+        "store_system_timestamp",
+        "tests/assets/user/artifacts/transactions/store_system_timestamp.mvt",
+    );
+    pub static INF_LOOP: Asset = Asset::new(
+        "inf_loop",
+        "tests/assets/user/artifacts/transactions/inf_loop.mvt",
+    );
+    pub static STORE_NATIVE_BALANCE: Asset = Asset::new(
+        "store_native_balance",
+        "tests/assets/user/artifacts/transactions/store_native_balance.mvt",
+    );
+    pub static TRANSFER: Asset = Asset::new(
+        "transfer",
+        "tests/assets/user/artifacts/transactions/transfer.mvt",
+    );
+    pub static MULTISIG_TEST: Asset = Asset::new(
+        "multisig_test",
+        "tests/assets/user/artifacts/transactions/multisig_test.mvt",
+    );
 }

--- a/pallets/sp-mvm/tests/common/utils.rs
+++ b/pallets/sp-mvm/tests/common/utils.rs
@@ -22,12 +22,8 @@ pub type AccountId = <Test as frame_system::Config>::AccountId;
 const DEFAULT_GAS_LIMIT: u64 = 1_000_000;
 
 /// Publish module __with__ storage check
-pub fn publish_module<Asset: BinAsset>(
-    signer: AccountId,
-    module: Asset,
-    gas_limit: Option<u64>,
-) -> PsResult {
-    let bytecode = module.bc().to_vec();
+pub fn publish_module(signer: AccountId, module: &Asset, gas_limit: Option<u64>) -> PsResult {
+    let bytecode = module.bytes().to_vec();
     let name = module.name();
     let result = publish_module_unchecked(signer, module, gas_limit)?;
     check_storage_module(to_move_addr(signer), bytecode, name);
@@ -35,24 +31,20 @@ pub fn publish_module<Asset: BinAsset>(
 }
 
 /// Publish module __without__ storage check
-pub fn publish_module_unchecked<Asset: BinAsset>(
+pub fn publish_module_unchecked(
     signer: AccountId,
-    module: Asset,
+    module: &Asset,
     gas_limit: Option<u64>,
 ) -> PsResult {
     let gas_limit = gas_limit.unwrap_or(DEFAULT_GAS_LIMIT);
-    Mvm::publish_module(Origin::signed(signer), module.bc().to_vec(), gas_limit)
+    Mvm::publish_module(Origin::signed(signer), module.bytes().to_vec(), gas_limit)
 }
 
 /// Publish package.
 ///
 /// Publish package __with__ storage check
-pub fn publish_package<Asset: BinAssetPackage>(
-    signer: AccountId,
-    package: Asset,
-    gas_limit: Option<u64>,
-) -> PsResult {
-    let bytecode = package.bc();
+pub fn publish_package(signer: AccountId, package: &Package, gas_limit: Option<u64>) -> PsResult {
+    let bytecode = package.bytes().to_vec();
     let names = package.modules();
     let result = publish_package_unchecked(signer, package, gas_limit)?;
     check_storage_package(to_move_addr(signer), bytecode, names);
@@ -60,19 +52,19 @@ pub fn publish_package<Asset: BinAssetPackage>(
 }
 
 /// Publish module __without__ storage check
-pub fn publish_package_unchecked<Asset: BinAsset>(
+pub fn publish_package_unchecked(
     signer: AccountId,
-    package: Asset,
+    package: &Package,
     gas_limit: Option<u64>,
 ) -> PsResult {
     let gas_limit = gas_limit.unwrap_or(DEFAULT_GAS_LIMIT);
-    Mvm::publish_package(Origin::signed(signer), package.bc().to_vec(), gas_limit)
+    Mvm::publish_package(Origin::signed(signer), package.bytes().to_vec(), gas_limit)
 }
 
-pub fn execute_tx(origin: AccountId, tx: UserTx, gas_limit: Option<u64>) -> PsResult {
+pub fn execute_tx(origin: AccountId, tx: &Asset, gas_limit: Option<u64>) -> PsResult {
     let gas_limit = gas_limit.unwrap_or(DEFAULT_GAS_LIMIT);
     // get bytecode:
-    let bc = tx.bc().to_vec();
+    let bc = tx.bytes().to_vec();
     // execute VM tx:
     let result = Mvm::execute(Origin::signed(origin), bc, gas_limit);
     eprintln!("execute tx result: {:?}", result);

--- a/pallets/sp-mvm/tests/gas.rs
+++ b/pallets/sp-mvm/tests/gas.rs
@@ -1,7 +1,7 @@
 use sp_runtime::DispatchError;
 
 mod common;
-use common::assets::*;
+use common::assets::{modules, transactions};
 use common::mock::*;
 use common::addr::*;
 use common::utils;
@@ -24,7 +24,8 @@ fn publish_module_gas_limit() {
     new_test_ext().execute_with(|| {
         let root = root_ps_acc();
 
-        let res = utils::publish_module(root, UserMod::EventProxy, Some(MINIMAL_GAS_LIMIT));
+        let res =
+            utils::publish_module(root, &modules::user::EVENT_PROXY, Some(MINIMAL_GAS_LIMIT));
 
         let error = res.unwrap_err().error;
         check_out_of_gas(error);
@@ -36,7 +37,7 @@ fn publish_gas_limit() {
     new_test_ext().execute_with(|| {
         let origin = origin_ps_acc();
 
-        let res = utils::publish_module(origin, UserMod::Store, Some(MINIMAL_GAS_LIMIT));
+        let res = utils::publish_module(origin, &modules::user::STORE, Some(MINIMAL_GAS_LIMIT));
 
         let error = res.unwrap_err().error;
         check_out_of_gas(error);
@@ -50,7 +51,7 @@ fn execute_gas_limit() {
 
         let origin = origin_ps_acc();
 
-        let res = common::utils::execute_tx(origin, UserTx::InfLoop, Some(GAS_LIMIT));
+        let res = common::utils::execute_tx(origin, &transactions::INF_LOOP, Some(GAS_LIMIT));
 
         let error = res.unwrap_err().error;
         check_out_of_gas(error);

--- a/pallets/sp-mvm/tests/multisig.rs
+++ b/pallets/sp-mvm/tests/multisig.rs
@@ -2,7 +2,7 @@ mod common;
 
 use common::mock::*;
 use common::addr::{alice_public_key, bob_public_key};
-use common::assets::{UserTx, BinAsset};
+use common::assets::transactions;
 
 use sp_mvm::Call as MvmCall;
 use frame_support::{assert_ok, dispatch::GetDispatchInfo};
@@ -20,7 +20,7 @@ fn execute_multisig() {
 
         let now = || Multisig::timepoint();
 
-        let bytecode = UserTx::MultisigTest.bc().to_vec();
+        let bytecode = transactions::MULTISIG_TEST.bytes().to_vec();
         let call = Call::Mvm(MvmCall::execute(bytecode, GAS_LIMIT));
         let weight = call.get_dispatch_info().weight;
         let call = call.encode();

--- a/pallets/sp-mvm/tests/storage.rs
+++ b/pallets/sp-mvm/tests/storage.rs
@@ -3,7 +3,7 @@ use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::StructTag;
 
 mod common;
-use common::assets::*;
+use common::assets::{modules, transactions};
 use common::mock::*;
 use common::addr::*;
 use common::utils;
@@ -12,7 +12,7 @@ use common::utils;
 fn publish_module() {
     new_test_ext().execute_with(|| {
         let origin = origin_ps_acc();
-        utils::publish_module(origin, UserMod::Store, None).unwrap();
+        utils::publish_module(origin, &modules::user::STORE, None).unwrap();
     });
 }
 
@@ -21,18 +21,18 @@ fn execute_script() {
     new_test_ext().execute_with(|| {
         let origin = origin_ps_acc();
 
-        utils::publish_module(origin, UserMod::Store, None).unwrap();
+        utils::publish_module(origin, &modules::user::STORE, None).unwrap();
 
         #[derive(Deserialize, Debug, PartialEq)]
         struct StoreU64 {
             pub val: u64,
         }
 
-        utils::execute_tx(origin, UserTx::StoreU64, None).unwrap();
+        utils::execute_tx(origin, &transactions::STORE_U64, None).unwrap();
 
         let tag = StructTag {
             address: origin_move_addr(),
-            module: Identifier::new(UserMod::Store.name()).unwrap(),
+            module: Identifier::new(modules::user::STORE.name()).unwrap(),
             name: Identifier::new("U64").unwrap(),
             type_params: vec![],
         };

--- a/pallets/sp-mvm/tests/tx-ctx.rs
+++ b/pallets/sp-mvm/tests/tx-ctx.rs
@@ -3,7 +3,7 @@ use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::StructTag;
 
 mod common;
-use common::assets::*;
+use common::assets::{modules, transactions};
 use common::mock::*;
 use common::addr::*;
 use common::utils::*;
@@ -18,7 +18,7 @@ fn check_stored_value(expected: u64) {
 
     let tag = StructTag {
         address: origin_move_addr(),
-        module: Identifier::new(UserMod::Store.name()).unwrap(),
+        module: Identifier::new(modules::user::STORE.name()).unwrap(),
         name: Identifier::new("U64").unwrap(),
         type_params: vec![],
     };
@@ -31,13 +31,13 @@ fn execute_store_block() {
     new_test_ext().execute_with(|| {
         let origin = origin_ps_acc();
 
-        publish_module(origin, UserMod::Store, None).unwrap();
+        publish_module(origin, &modules::user::STORE, None).unwrap();
 
         const EXPECTED: u64 = 3;
         for _ in 0..EXPECTED {
             roll_next_block();
         }
-        execute_tx(origin, UserTx::StoreSysBlock, None).unwrap();
+        execute_tx(origin, &transactions::STORE_SYSTEM_BLOCK, None).unwrap();
         check_stored_value(EXPECTED);
     });
 }
@@ -47,13 +47,13 @@ fn execute_store_time() {
     new_test_ext().execute_with(|| {
         let origin = origin_ps_acc();
 
-        publish_module(origin, UserMod::Store, None).unwrap();
+        publish_module(origin, &modules::user::STORE, None).unwrap();
 
         const EXPECTED: u64 = 3;
         for _ in 0..EXPECTED {
             roll_next_block();
         }
-        execute_tx(origin, UserTx::StoreSysTime, None).unwrap();
+        execute_tx(origin, &transactions::STORE_SYSTEM_TIMESTAMP, None).unwrap();
         check_stored_value(EXPECTED * TIME_BLOCK_MULTIPLIER);
     });
 }


### PR DESCRIPTION
A bunch of const variables and obscure enum -> array index conversions
were removed and replaced with Asset and Package structs. All modules
and transactions are available in a separate modules as static
variables. They are not Copy, so passing by reference is required.

Binary data is loaded in runtime using once_cell crate. It allows to
avoid recompilation on changes in assets.