### PR TITLE
Unboilerplatify code for defining currencies

### DIFF
--- a/primitives/src/currency.rs
+++ b/primitives/src/currency.rs
@@ -76,7 +76,18 @@ macro_rules! def_currencies {
             fn try_from(v: Vec<u8>) -> Result<Self, Self::Error> {
                 match &v[..] {
                     $($str => Ok(Self::$name),)*
-                    _ => Err(()),
+                    _ => Err(Self::Error::default()),
+                }
+            }
+        }
+
+        impl TryFrom<&'_ [u8]> for $ty_name {
+            type Error = CurrencyConversionError;
+
+            fn try_from(v: &'_ [u8]) -> Result<Self, Self::Error> {
+                match v {
+                    $($str => Ok(Self::$name),)*
+                    _ => Err(Self::Error::default()),
                 }
             }
         }
@@ -130,9 +141,17 @@ mod tests {
 
     #[test]
     /// Test try from Vec<u8>.
-    fn try_from() {
+    fn try_from_vec() {
         assert_eq!(CurrencyId::try_from(b"PONT".to_vec()), Ok(CurrencyId::PONT));
         assert_eq!(CurrencyId::try_from(b"KSM".to_vec()), Ok(CurrencyId::KSM));
         assert!(CurrencyId::try_from(b"UNKNOWN".to_vec()).is_err());
+    }
+
+    #[test]
+    /// Test try from &[u8].
+    fn try_from_slice() {
+        assert_eq!(CurrencyId::try_from(b"PONT".as_ref()), Ok(CurrencyId::PONT));
+        assert_eq!(CurrencyId::try_from(b"KSM".as_ref()), Ok(CurrencyId::KSM));
+        assert!(CurrencyId::try_from(b"UNKNOWN".as_ref()).is_err());
     }
 }

--- a/primitives/src/currency.rs
+++ b/primitives/src/currency.rs
@@ -99,6 +99,40 @@ def_currencies! {
 
 impl Default for CurrencyId {
     fn default() -> Self {
+        // PONT should be default currency.
         CurrencyId::PONT
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CurrencyId, TryFrom};
+
+    #[test]
+    /// Test default currency.
+    fn default() {
+        assert_eq!(CurrencyId::default(), CurrencyId::PONT);
+    }
+
+    #[test]
+    /// Test currencies decimals.
+    fn decimals() {
+        assert_eq!(CurrencyId::PONT.decimals(), 10);
+        assert_eq!(CurrencyId::KSM.decimals(), 12);
+    }
+
+    #[test]
+    /// Test currencies symbols.
+    fn symbols() {
+        assert_eq!(CurrencyId::PONT.symbol(), b"PONT");
+        assert_eq!(CurrencyId::KSM.symbol(), b"KSM");
+    }
+
+    #[test]
+    /// Test try from Vec<u8>.
+    fn try_from() {
+        assert_eq!(CurrencyId::try_from(b"PONT".to_vec()), Ok(CurrencyId::PONT));
+        assert_eq!(CurrencyId::try_from(b"KSM".to_vec()), Ok(CurrencyId::KSM));
+        assert!(CurrencyId::try_from(b"UNKNOWN".to_vec()).is_err());
     }
 }


### PR DESCRIPTION
This changes code to use a macro which enables easily adding new variants of currencies over time and excludes the possibility
of mismatching variants in impls. Also new macro statically ensures that byte string identifiers ascipted to variants conform their respective names.

Closes #137 