### PR TITLE
Use single source of truth for Pont decimals

### DIFF
--- a/constants/src/currency.rs
+++ b/constants/src/currency.rs
@@ -1,11 +1,8 @@
 /// Currencies constants.
-use primitives::Balance;
-
-/// Decimals.
-pub const DECIMALS: u32 = 10;
+use primitives::{Balance, currency::CurrencyId};
 
 /// Units.
-pub const PONT: Balance = u64::pow(10, DECIMALS);
+pub const PONT: Balance = u64::pow(10, CurrencyId::PONT.decimals() as _);
 pub const UNIT: Balance = PONT;
 pub const MILLIUNIT: Balance = UNIT / 1_000;
 pub const MICROUNIT: Balance = MILLIUNIT / 1_000;

--- a/primitives/src/currency.rs
+++ b/primitives/src/currency.rs
@@ -73,7 +73,7 @@ macro_rules! def_currencies {
         }
 
         impl $ty_name {
-            pub fn decimals(&self) -> u8 {
+            pub const fn decimals(&self) -> u8 {
                 match self {
                     $(Self::$name => $decimals,)*
                 }


### PR DESCRIPTION
Instead of keeping a dedicated constant in `constants` use value defined in `primitives`.
Issue: #141