### PR TITLE
fix link to gh-action

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Install Rust toolchain
         # uses: actions-rs/toolchain@v1
-        uses: zephraph/toolchain@support-toolchain-toml
+        uses: oxidecomputer/actions-rs_toolchain@oxide/master
         with:
           profile: minimal
           override: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
 
       - name: Install Rust toolchain
         # uses: actions-rs/toolchain@v1
-        uses: zephraph/toolchain@support-toolchain-toml
+        uses: oxidecomputer/actions-rs_toolchain@oxide/master
         with:
           profile: minimal
           target: wasm32-unknown-unknown

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install Rust toolchain
         # uses: actions-rs/toolchain@v1
-        uses: zephraph/toolchain@support-toolchain-toml
+        uses: oxidecomputer/actions-rs_toolchain@oxide/master
         with:
           profile: minimal
           components: rustfmt
@@ -85,7 +85,7 @@ jobs:
 
       - name: Install Rust toolchain
         # uses: actions-rs/toolchain@v1
-        uses: zephraph/toolchain@support-toolchain-toml
+        uses: oxidecomputer/actions-rs_toolchain@oxide/master
         with:
           profile: minimal
           components: clippy
@@ -130,7 +130,7 @@ jobs:
 
       - name: Install Rust toolchain
         # uses: actions-rs/toolchain@v1
-        uses: zephraph/toolchain@support-toolchain-toml
+        uses: oxidecomputer/actions-rs_toolchain@oxide/master
         with:
           profile: minimal
           target: wasm32-unknown-unknown
@@ -181,7 +181,7 @@ jobs:
 
       - name: Install Rust toolchain
         # uses: actions-rs/toolchain@v1
-        uses: zephraph/toolchain@support-toolchain-toml
+        uses: oxidecomputer/actions-rs_toolchain@oxide/master
         with:
           profile: minimal
           target: wasm32-unknown-unknown


### PR DESCRIPTION
Changed link to third-party gh-action (zephraph/toolchain -> oxidecomputer/actions-rs_toolchain).
Fixes [that](https://github.com/pontem-network/pontem/issues/180#issuecomment-1033305546), following #176.