### PR TITLE
CI: fix release branch name pattern to wild wildcard (`**`)

### DIFF
--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-      - release-v?[0-9]+.[0-9]+.*
+      - release-v?[0-9]+.[0-9]+**
 
 jobs:
   push-tag:


### PR DESCRIPTION
Needed for release-branches.
About `**` see doc [1](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore) and [2](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet).